### PR TITLE
Remove arrow function from `parseHeaders`

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@
   }
 
   function parseHeaders(headers) {
-    return AUTH_FIELDS.reduce((memo, field) => {
+    return AUTH_FIELDS.reduce(function(memo, field) {
       memo[field] = headers.get(field);
 
       return memo;


### PR DESCRIPTION
This should be the last removal of non-ES5 code that is breaking Uglify
builds.